### PR TITLE
Share SSO sessions across awseal profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,42 +48,55 @@ brew install awseal
 
 ### 1. Configure awseal
 
-`awseal` is configured via `~/.awseal/config.json`:
+`awseal` reads profile settings from `~/.aws/config` using `awseal_`-prefixed
+keys:
 
-```json
-{
-  "default": {
-    "ssoStartUrl": "https://xxx.awsapps.com/start/#",
-    "ssoRegion": "eu-west-2",
-    "region": "eu-west-2",
-    "accountId": "123456789012",
-    "roleName": "MyRole"
-  },
-  "dev": {
-    "ssoStartUrl": "https://xxx.awsapps.com/start/#",
-    "ssoRegion": "eu-west-2",
-    "region": "eu-west-2",
-    "accountId": "123456789012",
-    "roleName": "Developer"
-  }
-}
+```ini
+[default]
+region = eu-west-2
+awseal_sso_session = company
+awseal_sso_start_url = https://xxx.awsapps.com/start/#
+awseal_sso_region = eu-west-2
+awseal_sso_account_id = 123456789012
+awseal_sso_role_name = MyRole
+credential_process = awseal fetch-role-creds --autologin
+
+[profile dev]
+region = eu-west-2
+awseal_sso_session = company
+awseal_sso_start_url = https://xxx.awsapps.com/start/#
+awseal_sso_region = eu-west-2
+awseal_sso_account_id = 123456789012
+awseal_sso_role_name = Developer
+credential_process = awseal fetch-role-creds --profile dev --autologin
 ```
 
-The top level attributes are the profiles you can reference through
-`--profile`. The default profile is used if this option is omitted. The
+The `[profile name]` sections are the profiles you can reference through
+`--profile name`. The `[default]` profile is used if this option is omitted. The
 available configuration options for each profile are:
 
-- **ssoStartUrl**: Your organization's AWS SSO start URL
-- **ssoRegion**: AWS region where SSO is configured
+- **awseal_sso_session**: Optional shared SSO session name. Profiles with the same
+  value share one encrypted SSO login. If omitted, awseal shares SSO
+  credentials across profiles with the same `awseal_sso_start_url` and
+  `awseal_sso_region`.
+- **awseal_sso_start_url**: Your organization's AWS SSO start URL
+- **awseal_sso_region**: AWS region where SSO is configured
 - **region**: Default AWS region for API calls
-- **accountId**: Your AWS account ID
-- **roleName**: The role you want to assume
+- **awseal_sso_account_id**: Your AWS account ID
+- **awseal_sso_role_name**: The role you want to assume
+
+Values in `[default]` are inherited by named profiles. For compatibility,
+`~/.awseal/config.json` is still loaded when present, but `~/.aws/config`
+profiles take precedence.
 
 ### 2. Login to AWS SSO
 
 ```bash
 awseal login
 ```
+
+Profiles that share the same `awseal_sso_session` use the same encrypted SSO
+login, so you only need to login once before switching between those profiles.
 
 This will:
 
@@ -93,9 +106,8 @@ This will:
 
 ### 3. Configure AWS CLI
 
-Configure the AWS CLI to use `awseal` as an external credential provider by
-setting `awseal` as the `credential_process` for each profile you want to use
-it with in `~/.aws/config`:
+Configure each AWS CLI profile to use `awseal` as an external credential
+provider by setting `credential_process`:
 
 ```ini
 [default]
@@ -103,6 +115,18 @@ credential_process = awseal fetch-role-creds
 
 [profile my-profile]
 credential_process = awseal fetch-role-creds --profile my-profile
+```
+
+To allow `credential_process` to open the browser and login automatically when
+the encrypted SSO credentials are missing or can no longer be refreshed, add
+`--autologin`:
+
+```ini
+[default]
+credential_process = awseal fetch-role-creds --autologin
+
+[profile my-profile]
+credential_process = awseal fetch-role-creds --profile my-profile --autologin
 ```
 
 ### 4. Use AWS CLI Normally
@@ -142,14 +166,16 @@ Enclave key
 1. **Login Phase** (`awseal login`):
    - Authenticate with AWS SSO via browser
    - Generate Secure Enclave key
-   - Encrypt and store SSO credentials
+   - Encrypt and store SSO credentials for the shared SSO session
 
 2. **Credential Fetching** (`awseal fetch-role-creds`):
    - AWS CLI calls awseal via `credential_process`
    - awseal decrypts stored credentials (requires Touch ID/Face ID)
    - Role credentials are fetched from AWS SSO OIDC API and returned to AWS CLI
-   - Role credentials are stored encrypted until they expire
+   - Role credentials are stored encrypted per profile until they expire
    - Refresh tokens are used to keep access tokens short-lived for OIDC
+   - With `--autologin`, awseal opens the browser and performs SSO login when
+     the encrypted SSO credentials are missing or cannot be refreshed
 
 3. **Security Guarantees**:
    - Credentials are never stored in plain text

--- a/README.md
+++ b/README.md
@@ -89,6 +89,32 @@ Values in `[default]` are inherited by named profiles. For compatibility,
 `~/.awseal/config.json` is still loaded when present, but `~/.aws/config`
 profiles take precedence.
 
+#### Migrating AWS CLI SSO profiles
+
+If you already have AWS CLI SSO profiles using `sso_session`,
+`sso_account_id`, and `sso_role_name`, migrate them in place:
+
+```bash
+awseal migrate
+```
+
+This creates a backup next to `~/.aws/config`, removes the vanilla AWS SSO keys
+from migrated profiles, adds the equivalent `awseal_sso_*` keys, and installs
+`credential_process = awseal fetch-role-creds ... --autologin`.
+
+Preview without writing:
+
+```bash
+awseal migrate --dry-run
+```
+
+Useful options:
+
+- `--config <path>`: migrate a specific AWS config file
+- `--no-autologin`: omit `--autologin` from generated `credential_process`
+  entries
+- `--no-backup`: write in place without creating a backup
+
 ### 2. Login to AWS SSO
 
 ```bash

--- a/Sources/Awseal.swift
+++ b/Sources/Awseal.swift
@@ -363,6 +363,22 @@ struct AWSEALConfig: Codable {
     }
 }
 
+func parseConfigKeyValue(_ line: String) -> (key: String, value: String)? {
+    let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+    if trimmed.isEmpty || trimmed.hasPrefix("#") || trimmed.hasPrefix(";") {
+        return nil
+    }
+
+    guard let separator = trimmed.firstIndex(of: "=") else {
+        return nil
+    }
+
+    let key = trimmed[..<separator].trimmingCharacters(in: .whitespaces)
+    let value = trimmed[trimmed.index(after: separator)...].trimmingCharacters(in: .whitespaces)
+    return (key, value)
+}
+
 func parseAWSConfig(_ text: String) -> [String: [String: String]] {
     var sections: [String: [String: String]] = [:]
     var currentSection: String?
@@ -387,17 +403,242 @@ func parseAWSConfig(_ text: String) -> [String: [String: String]] {
         }
 
         guard let currentSection,
-              let separator = line.firstIndex(of: "=")
+              let (key, value) = parseConfigKeyValue(line)
         else {
             continue
         }
 
-        let key = line[..<separator].trimmingCharacters(in: .whitespaces)
-        let value = line[line.index(after: separator)...].trimmingCharacters(in: .whitespaces)
         sections[currentSection]?[key] = value
     }
 
     return sections
+}
+
+struct AWSConfigSection {
+    var headerLine: String?
+    var name: String?
+    var lines: [String]
+
+    var values: [String: String] {
+        var values: [String: String] = [:]
+        for line in lines {
+            if let (key, value) = parseConfigKeyValue(line) {
+                values[key] = value
+            }
+        }
+        return values
+    }
+
+    var isProfileSection: Bool {
+        guard let name else {
+            return false
+        }
+
+        return name == "default" || !name.hasPrefix("sso-session ")
+    }
+
+    mutating func removeKeys(_ keys: Set<String>) {
+        lines.removeAll { line in
+            guard let (key, _) = parseConfigKeyValue(line) else {
+                return false
+            }
+            return keys.contains(key)
+        }
+    }
+
+    mutating func removeTrailingBlankLines() -> [String] {
+        var trailingBlankLines: [String] = []
+        while let last = lines.last,
+              last.trimmingCharacters(in: .whitespaces).isEmpty {
+            trailingBlankLines.insert(lines.removeLast(), at: 0)
+        }
+        return trailingBlankLines
+    }
+
+    mutating func appendKeyValue(_ key: String, _ value: String) {
+        lines.append("\(key) = \(value)")
+    }
+}
+
+struct AWSConfigDocument {
+    var sections: [AWSConfigSection]
+    let hadTrailingNewline: Bool
+
+    static func parse(_ text: String) -> AWSConfigDocument {
+        var sections: [AWSConfigSection] = [
+            AWSConfigSection(headerLine: nil, name: nil, lines: [])
+        ]
+
+        for rawLine in text.split(separator: "\n", omittingEmptySubsequences: false) {
+            let line = String(rawLine)
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            if trimmed.hasPrefix("[") && trimmed.hasSuffix("]") {
+                var sectionName = String(trimmed.dropFirst().dropLast()).trimmingCharacters(in: .whitespaces)
+                if sectionName.hasPrefix("profile ") {
+                    sectionName = String(sectionName.dropFirst("profile ".count))
+                }
+                sections.append(AWSConfigSection(headerLine: line, name: sectionName, lines: []))
+            } else {
+                sections[sections.count - 1].lines.append(line)
+            }
+        }
+
+        if text.hasSuffix("\n"), sections.last?.lines.last == "" {
+            sections[sections.count - 1].lines.removeLast()
+        }
+
+        return AWSConfigDocument(sections: sections, hadTrailingNewline: text.hasSuffix("\n"))
+    }
+
+    func rendered() -> String {
+        var outputLines: [String] = []
+
+        for section in sections {
+            if let headerLine = section.headerLine {
+                outputLines.append(headerLine)
+            }
+            outputLines.append(contentsOf: section.lines)
+        }
+
+        var output = outputLines.joined(separator: "\n")
+        if hadTrailingNewline {
+            output += "\n"
+        }
+        return output
+    }
+
+    mutating func migrateToAwseal(addAutologin: Bool) -> [String] {
+        var ssoSessions: [String: [String: String]] = [:]
+        let defaultValues = sections.first { $0.name == "default" }?.values ?? [:]
+
+        for section in sections {
+            guard let name = section.name,
+                  name.hasPrefix("sso-session ")
+            else {
+                continue
+            }
+
+            let sessionName = String(name.dropFirst("sso-session ".count))
+            ssoSessions[sessionName] = section.values
+        }
+
+        var migratedProfiles: [String] = []
+        let vanillaKeys: Set<String> = [
+            "sso_session",
+            "sso_start_url",
+            "sso_region",
+            "sso_account_id",
+            "sso_role_name",
+        ]
+        let awsealKeys: Set<String> = [
+            "awseal_sso_session",
+            "awseal_sso_start_url",
+            "awseal_sso_region",
+            "awseal_sso_account_id",
+            "awseal_sso_role_name",
+            "credential_process",
+        ]
+
+        for index in sections.indices {
+            guard sections[index].isProfileSection,
+                  let profileName = sections[index].name
+            else {
+                continue
+            }
+
+            let values = sections[index].values
+            func value(_ key: String) -> String? {
+                values[key] ?? defaultValues[key]
+            }
+
+            guard let accountId = value("sso_account_id"),
+                  let roleName = value("sso_role_name")
+            else {
+                continue
+            }
+
+            let ssoSession = value("sso_session")
+            let ssoStartUrl: String?
+            let ssoRegion: String?
+            if let ssoSession {
+                let sessionValues = ssoSessions[ssoSession] ?? [:]
+                ssoStartUrl = sessionValues["sso_start_url"]
+                ssoRegion = sessionValues["sso_region"]
+            } else {
+                ssoStartUrl = value("sso_start_url")
+                ssoRegion = value("sso_region")
+            }
+
+            guard let ssoStartUrl,
+                  let ssoRegion
+            else {
+                continue
+            }
+
+            sections[index].removeKeys(vanillaKeys.union(awsealKeys))
+            let trailingBlankLines = sections[index].removeTrailingBlankLines()
+
+            if value("region") == nil {
+                sections[index].appendKeyValue("region", ssoRegion)
+            }
+            if let ssoSession {
+                sections[index].appendKeyValue("awseal_sso_session", ssoSession)
+            }
+            sections[index].appendKeyValue("awseal_sso_start_url", ssoStartUrl)
+            sections[index].appendKeyValue("awseal_sso_region", ssoRegion)
+            sections[index].appendKeyValue("awseal_sso_account_id", accountId)
+            sections[index].appendKeyValue("awseal_sso_role_name", roleName)
+
+            var credentialProcess = "awseal fetch-role-creds"
+            if profileName != "default" {
+                credentialProcess += " --profile \(profileName)"
+            }
+            if addAutologin {
+                credentialProcess += " --autologin"
+            }
+            sections[index].appendKeyValue("credential_process", credentialProcess)
+            sections[index].lines.append(contentsOf: trailingBlankLines)
+            migratedProfiles.append(profileName)
+        }
+
+        return migratedProfiles
+    }
+}
+
+func expandTilde(_ path: String) -> String {
+    if path == "~" {
+        return FileManager.default.homeDirectoryForCurrentUser.path
+    }
+
+    if path.hasPrefix("~/") {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return home + String(path.dropFirst())
+    }
+
+    return path
+}
+
+func timestampForBackup() -> String {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyyMMddHHmmss"
+    return formatter.string(from: Date())
+}
+
+func posixPermissions(at url: URL) -> NSNumber? {
+    guard let attributes = try? FileManager.default.attributesOfItem(atPath: url.path) else {
+        return nil
+    }
+
+    return attributes[.posixPermissions] as? NSNumber
+}
+
+func setPosixPermissions(_ permissions: NSNumber?, at url: URL) throws {
+    guard let permissions else {
+        return
+    }
+
+    try FileManager.default.setAttributes([.posixPermissions: permissions], ofItemAtPath: url.path)
 }
 
 func loadConfig() throws -> AWSEALConfig {
@@ -795,7 +1036,7 @@ struct Awseal: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "An AWS CLI credential_process using AWS SSO to mint credentials while storing secrets under a Secure Enclave key.",
         version: "0.3.1",
-        subcommands: [Login.self, FetchRoleCreds.self]
+        subcommands: [Login.self, FetchRoleCreds.self, Migrate.self]
     )
 }
 
@@ -810,6 +1051,20 @@ struct FetchRoleCredsOptions: ParsableArguments {
 
     @Flag(help: "Open a browser and login when cached SSO credentials are missing or cannot be refreshed.")
     var autologin = false
+}
+
+struct MigrateOptions: ParsableArguments {
+    @Option(help: "Path to the AWS config file to migrate.")
+    var config = "~/.aws/config"
+
+    @Flag(help: "Print the migrated config without writing it.")
+    var dryRun = false
+
+    @Flag(help: "Do not create a backup before writing.")
+    var noBackup = false
+
+    @Flag(help: "Do not add --autologin to generated credential_process entries.")
+    var noAutologin = false
 }
 
 extension Awseal {
@@ -848,6 +1103,47 @@ extension Awseal {
                 autologin: options.autologin
             )
             printRoleCredentials(creds: creds)
+        }
+    }
+
+    struct Migrate: ParsableCommand {
+        static let configuration = CommandConfiguration(
+            abstract: "Migrate AWS CLI SSO profiles in ~/.aws/config to awseal credential_process profiles."
+        )
+
+        @OptionGroup var options: MigrateOptions
+
+        func run() throws {
+            let configPath = expandTilde(options.config)
+            let configURL = URL(fileURLWithPath: configPath)
+            let original = try String(contentsOf: configURL, encoding: .utf8)
+            let permissions = posixPermissions(at: configURL)
+            var document = AWSConfigDocument.parse(original)
+            let migratedProfiles = document.migrateToAwseal(addAutologin: !options.noAutologin)
+
+            guard !migratedProfiles.isEmpty else {
+                throw AwsealError.generic("No vanilla AWS SSO profiles found in \(configURL.path)")
+            }
+
+            let migrated = document.rendered()
+            if options.dryRun {
+                print(migrated, terminator: "")
+                printError("Would migrate profiles: \(migratedProfiles.joined(separator: ", "))\n")
+                return
+            }
+
+            if !options.noBackup {
+                let backupURL = configURL
+                    .deletingLastPathComponent()
+                    .appendingPathComponent("\(configURL.lastPathComponent).awseal-backup-\(timestampForBackup())")
+                try original.write(to: backupURL, atomically: true, encoding: .utf8)
+                try setPosixPermissions(permissions, at: backupURL)
+                print("Backup written to \(backupURL.path)")
+            }
+
+            try migrated.write(to: configURL, atomically: true, encoding: .utf8)
+            try setPosixPermissions(permissions, at: configURL)
+            print("Migrated profiles: \(migratedProfiles.joined(separator: ", "))")
         }
     }
 

--- a/Sources/Awseal.swift
+++ b/Sources/Awseal.swift
@@ -3,6 +3,7 @@ import AWSSSO
 import AWSSSOOIDC
 import Foundation
 import CryptoKit
+import Darwin
 import LocalAuthentication
 import Security
 
@@ -175,7 +176,7 @@ func saveEncrypted(plaintext: Data, to: URL) throws {
     try out.write(to: to, options: [.atomic])
 }
 
-func loadDecrypted(from: URL) throws -> Data {
+func loadDecrypted(from: URL, reason: String) throws -> Data {
     let recoveryInstructions = "Delete ~/.awseal/keys.json if it exsists and run `awseal login` again."
     let db = try KeyDB()
     guard let md = db.resolve(keyLabel) else {
@@ -191,7 +192,7 @@ func loadDecrypted(from: URL) throws -> Data {
         throw AwsealError.generic("Envelope key ID (\(envelope.keyId)) doesn't match requested key (\(md.id)). \(recoveryInstructions)")
     }
 
-    let priv = try EnclaveKeyManager.openPrivateKey(md, reason: "decrypt AWS credentials")
+    let priv = try EnclaveKeyManager.openPrivateKey(md, reason: reason)
 
     var hpke = try HPKE.Recipient(
         privateKey: priv,
@@ -202,6 +203,92 @@ func loadDecrypted(from: URL) throws -> Data {
     let plaintext = try hpke.open(envelope.ciphertext)
     
     return plaintext
+}
+
+struct ProcessDetails {
+    let ppid: pid_t
+    let command: String
+}
+
+func processDetails(pid: pid_t) -> ProcessDetails? {
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/bin/ps")
+    process.arguments = ["-o", "ppid=", "-o", "command=", "-p", "\(pid)"]
+
+    let pipe = Pipe()
+    process.standardOutput = pipe
+    process.standardError = Pipe()
+
+    do {
+        try process.run()
+        process.waitUntilExit()
+    } catch {
+        return nil
+    }
+
+    guard process.terminationStatus == 0 else {
+        return nil
+    }
+
+    let data = pipe.fileHandleForReading.readDataToEndOfFile()
+    guard let output = String(data: data, encoding: .utf8) else {
+        return nil
+    }
+
+    let line = output.trimmingCharacters(in: .whitespacesAndNewlines)
+    let parts = line.split(maxSplits: 1, whereSeparator: { $0 == " " || $0 == "\t" })
+    guard parts.count == 2, let ppid = pid_t(String(parts[0])) else {
+        return nil
+    }
+
+    return ProcessDetails(ppid: ppid, command: String(parts[1]))
+}
+
+func executableName(command: String) -> String? {
+    guard let executable = command.split(whereSeparator: { $0 == " " || $0 == "\t" }).first else {
+        return nil
+    }
+
+    return URL(fileURLWithPath: String(executable)).lastPathComponent
+}
+
+func truncateForPrompt(_ value: String, maxLength: Int = 160) -> String {
+    guard value.count > maxLength else {
+        return value
+    }
+
+    return "\(value.prefix(maxLength - 1))..."
+}
+
+func requestingCommand() -> String? {
+    var pid = getppid()
+    var fallbackCommand: String?
+
+    for _ in 0..<8 {
+        guard pid > 1, let details = processDetails(pid: pid) else {
+            break
+        }
+
+        if fallbackCommand == nil {
+            fallbackCommand = details.command
+        }
+
+        if executableName(command: details.command) == "aws" {
+            return truncateForPrompt(details.command)
+        }
+
+        pid = details.ppid
+    }
+
+    return fallbackCommand.map { truncateForPrompt($0) }
+}
+
+func decryptReason(description: String) -> String {
+    guard let command = requestingCommand() else {
+        return "Decrypt \(description)"
+    }
+
+    return "Decrypt \(description) for: \(command)"
 }
 
 struct AWSEALProfile: Codable {
@@ -380,14 +467,14 @@ func awsealDirectory() throws -> URL {
     return dirURL
 }
 
-func loadEncryptedJSON<T: Decodable>(fileName: String, as type: T.Type) throws -> T? {
+func loadEncryptedJSON<T: Decodable>(fileName: String, as type: T.Type, reason: String) throws -> T? {
     let fileURL = try awsealDirectory().appendingPathComponent(fileName)
 
     guard FileManager.default.fileExists(atPath: fileURL.path) else {
         return nil
     }
 
-    let data = try loadDecrypted(from: fileURL)
+    let data = try loadDecrypted(from: fileURL, reason: reason)
     return try JSONDecoder().decode(type, from: data)
 }
 
@@ -470,8 +557,13 @@ func ssoLogin(
 }
 
 func loadSsoCreds(profileConfig: AWSEALProfile) throws -> SsoCreds? {
-    let fileName = ssoCredsCacheFileName(ssoSession: profileConfig.effectiveSsoSession)
-    return try loadEncryptedJSON(fileName: fileName, as: SsoCreds.self)
+    let ssoSession = profileConfig.effectiveSsoSession
+    let fileName = ssoCredsCacheFileName(ssoSession: ssoSession)
+    return try loadEncryptedJSON(
+        fileName: fileName,
+        as: SsoCreds.self,
+        reason: decryptReason(description: "AWS SSO credentials for session \(ssoSession)")
+    )
 }
 
 func saveSsoCreds(ssoSession: String, ssoCreds: SsoCreds) throws {
@@ -480,7 +572,11 @@ func saveSsoCreds(ssoSession: String, ssoCreds: SsoCreds) throws {
 
 func loadRoleCreds(profile: String) throws -> RoleCreds? {
     let fileName = roleCredsCacheFileName(profile: profile)
-    return try loadEncryptedJSON(fileName: fileName, as: RoleCreds.self)
+    return try loadEncryptedJSON(
+        fileName: fileName,
+        as: RoleCreds.self,
+        reason: decryptReason(description: "AWS role credentials for profile \(profile)")
+    )
 }
 
 func saveRoleCreds(profile: String, roleCreds: RoleCreds) throws {

--- a/Sources/Awseal.swift
+++ b/Sources/Awseal.swift
@@ -252,6 +252,55 @@ func executableName(command: String) -> String? {
     return URL(fileURLWithPath: String(executable)).lastPathComponent
 }
 
+func commandParts(_ command: String) -> [Substring] {
+    command.split(whereSeparator: { $0 == " " || $0 == "\t" })
+}
+
+func isInteractiveShellCommand(_ command: String) -> Bool {
+    let parts = commandParts(command)
+    guard let executable = parts.first else {
+        return false
+    }
+
+    let shellName = URL(fileURLWithPath: String(executable)).lastPathComponent.trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+    let interactiveShells: Set<String> = ["sh", "bash", "zsh", "fish", "ksh", "dash", "tcsh", "csh"]
+    guard interactiveShells.contains(shellName) else {
+        return false
+    }
+
+    let args = parts.dropFirst().map(String.init)
+    if args.isEmpty {
+        return true
+    }
+
+    if args.contains("-c") || args.contains(where: { $0.hasPrefix("-c") && $0.count > 2 }) {
+        return false
+    }
+
+    return args.allSatisfy { $0.hasPrefix("-") }
+}
+
+func commandForPrompt(_ command: String) -> String {
+    let parts = commandParts(command)
+    guard let executable = parts.first else {
+        return command
+    }
+
+    let displayExecutable = URL(fileURLWithPath: String(executable)).lastPathComponent
+    if displayExecutable.lowercased().hasPrefix("python"),
+       parts.count >= 2,
+       URL(fileURLWithPath: String(parts[1])).lastPathComponent == "aws" {
+        let arguments = parts.dropFirst(2).joined(separator: " ")
+        return arguments.isEmpty ? "aws" : "aws \(arguments)"
+    }
+
+    guard parts.count >= 2 else {
+        return displayExecutable
+    }
+
+    return "\(displayExecutable) \(parts.dropFirst().joined(separator: " "))"
+}
+
 func truncateForPrompt(_ value: String, maxLength: Int = 160) -> String {
     guard value.count > maxLength else {
         return value
@@ -263,18 +312,24 @@ func truncateForPrompt(_ value: String, maxLength: Int = 160) -> String {
 func requestingCommand() -> String? {
     var pid = getppid()
     var fallbackCommand: String?
+    let preferredCommands: Set<String> = ["kubectl"]
 
-    for _ in 0..<8 {
+    for _ in 0..<16 {
         guard pid > 1, let details = processDetails(pid: pid) else {
             break
         }
 
         if fallbackCommand == nil {
-            fallbackCommand = details.command
+            fallbackCommand = commandForPrompt(details.command)
         }
 
-        if executableName(command: details.command) == "aws" {
-            return truncateForPrompt(details.command)
+        if isInteractiveShellCommand(details.command) {
+            break
+        }
+
+        if let executable = executableName(command: details.command),
+           preferredCommands.contains(executable) {
+            return truncateForPrompt(commandForPrompt(details.command))
         }
 
         pid = details.ppid
@@ -283,12 +338,12 @@ func requestingCommand() -> String? {
     return fallbackCommand.map { truncateForPrompt($0) }
 }
 
-func decryptReason(description: String) -> String {
+func decryptReason(subject: String) -> String {
     guard let command = requestingCommand() else {
-        return "Decrypt \(description)"
+        return "use \(subject) to decrypt AWS credentials"
     }
 
-    return "Decrypt \(description) for: \(command)"
+    return "use \(subject) to decrypt AWS credentials for \(command)"
 }
 
 struct AWSEALProfile: Codable {
@@ -803,7 +858,7 @@ func loadSsoCreds(profileConfig: AWSEALProfile) throws -> SsoCreds? {
     return try loadEncryptedJSON(
         fileName: fileName,
         as: SsoCreds.self,
-        reason: decryptReason(description: "AWS SSO credentials for session \(ssoSession)")
+        reason: decryptReason(subject: "AWS SSO session \(ssoSession)")
     )
 }
 
@@ -816,7 +871,7 @@ func loadRoleCreds(profile: String) throws -> RoleCreds? {
     return try loadEncryptedJSON(
         fileName: fileName,
         as: RoleCreds.self,
-        reason: decryptReason(description: "AWS role credentials for profile \(profile)")
+        reason: decryptReason(subject: "AWS profile \(profile)")
     )
 }
 
@@ -1035,7 +1090,7 @@ func printRoleCredentials(creds: RoleCreds) {
 struct Awseal: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "An AWS CLI credential_process using AWS SSO to mint credentials while storing secrets under a Secure Enclave key.",
-        version: "0.3.1",
+        version: "0.3.2",
         subcommands: [Login.self, FetchRoleCreds.self, Migrate.self]
     )
 }

--- a/Sources/Awseal.swift
+++ b/Sources/Awseal.swift
@@ -879,6 +879,15 @@ func saveRoleCreds(profile: String, roleCreds: RoleCreds) throws {
     try saveEncryptedJSON(roleCreds, fileName: roleCredsCacheFileName(profile: profile))
 }
 
+func deleteRoleCreds(profile: String) throws {
+    let fileURL = try awsealDirectory().appendingPathComponent(roleCredsCacheFileName(profile: profile))
+    guard FileManager.default.fileExists(atPath: fileURL.path) else {
+        return
+    }
+
+    try FileManager.default.removeItem(at: fileURL)
+}
+
 func registerClient(oidc: SSOOIDCClient, ssoSession: String) async throws -> SsoCreds {
     let input = RegisterClientInput(
         clientName: "awseal-\(cacheKey(ssoSession).prefix(16))",
@@ -902,10 +911,16 @@ func registerClient(oidc: SSOOIDCClient, ssoSession: String) async throws -> Sso
     return ssoCreds
 }
 
-func loginToSso(profileConfig: AWSEALProfile, oidc: SSOOIDCClient) async throws -> SsoCreds {
+func loginToSso(
+    profileConfig: AWSEALProfile,
+    oidc: SSOOIDCClient,
+    existingSsoCreds: SsoCreds? = nil
+) async throws -> SsoCreds {
     let ssoSession = profileConfig.effectiveSsoSession
     var ssoCreds: SsoCreds
-    if let existing = try loadSsoCreds(profileConfig: profileConfig) {
+    if let existing = existingSsoCreds {
+        ssoCreds = existing
+    } else if let existing = try loadSsoCreds(profileConfig: profileConfig) {
         ssoCreds = existing
     } else {
         ssoCreds = try await registerClient(oidc: oidc, ssoSession: ssoSession)
@@ -985,6 +1000,7 @@ func fetchRoleCreds(
         if !roleCreds.hasExpired {
             return roleCreds
         }
+        try deleteRoleCreds(profile: profile)
     }
     // role creds not present or expired
 
@@ -1002,7 +1018,11 @@ func fetchRoleCreds(
         guard autologin else {
             throw AwsealError.notLoggedIn
         }
-        ssoCreds = try await loginToSso(profileConfig: profileConfig, oidc: oidc)
+        ssoCreds = try await loginToSso(
+            profileConfig: profileConfig,
+            oidc: oidc,
+            existingSsoCreds: ssoCreds
+        )
     }
 
     guard let accessToken = ssoCreds.accessToken else {
@@ -1028,7 +1048,11 @@ func fetchRoleCreds(
             guard autologin else {
                 throw error
             }
-            ssoCreds = try await loginToSso(profileConfig: profileConfig, oidc: oidc)
+            ssoCreds = try await loginToSso(
+                profileConfig: profileConfig,
+                oidc: oidc,
+                existingSsoCreds: ssoCreds
+            )
         }
 
         guard let accessToken = ssoCreds.accessToken else {

--- a/Sources/Awseal.swift
+++ b/Sources/Awseal.swift
@@ -210,16 +210,62 @@ struct AWSEALProfile: Codable {
     let accountId: String
     let region: String
     let ssoRegion: String
+    let ssoSession: String?
+
+    var effectiveSsoSession: String {
+        guard let ssoSession = ssoSession?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !ssoSession.isEmpty
+        else {
+            return "\(ssoRegion)|\(ssoStartUrl)"
+        }
+        return ssoSession
+    }
 }
 
 struct AWSEALConfig: Codable {
     let profiles: [String: AWSEALProfile]
 
-    static func load(from url: URL) throws -> AWSEALConfig {
+    static func load(fromJSON url: URL) throws -> AWSEALConfig {
         let data = try Data(contentsOf: url)
         let decoder = JSONDecoder()
         let rawProfiles = try decoder.decode([String: AWSEALProfile].self, from: data)
         return AWSEALConfig(profiles: rawProfiles)
+    }
+
+    static func load(fromAWSConfig url: URL) throws -> AWSEALConfig {
+        let data = try Data(contentsOf: url)
+        guard let text = String(data: data, encoding: .utf8) else {
+            throw AwsealError.generic("Unable to read \(url.path) as UTF-8")
+        }
+
+        let sections = parseAWSConfig(text)
+        let defaults = sections["default"] ?? [:]
+        var profiles: [String: AWSEALProfile] = [:]
+
+        for (name, values) in sections {
+            func value(_ key: String) -> String? {
+                values[key] ?? defaults[key]
+            }
+
+            guard let ssoStartUrl = value("awseal_sso_start_url"),
+                  let ssoRegion = value("awseal_sso_region"),
+                  let accountId = value("awseal_sso_account_id"),
+                  let roleName = value("awseal_sso_role_name")
+            else {
+                continue
+            }
+
+            profiles[name] = AWSEALProfile(
+                ssoStartUrl: ssoStartUrl,
+                roleName: roleName,
+                accountId: accountId,
+                region: value("region") ?? ssoRegion,
+                ssoRegion: ssoRegion,
+                ssoSession: value("awseal_sso_session")
+            )
+        }
+
+        return AWSEALConfig(profiles: profiles)
     }
 
     func profile(named name: String) throws -> AWSEALProfile {
@@ -230,16 +276,62 @@ struct AWSEALConfig: Codable {
     }
 }
 
-func loadConfig() throws -> AWSEALConfig {
-    let home = FileManager.default.homeDirectoryForCurrentUser
-    let configURL = home.appendingPathComponent(".awseal/config.json")
-    let config = try AWSEALConfig.load(from: configURL)
-    return config
+func parseAWSConfig(_ text: String) -> [String: [String: String]] {
+    var sections: [String: [String: String]] = [:]
+    var currentSection: String?
+
+    for rawLine in text.split(separator: "\n", omittingEmptySubsequences: false) {
+        let line = rawLine.trimmingCharacters(in: .whitespaces)
+
+        if line.isEmpty || line.hasPrefix("#") || line.hasPrefix(";") {
+            continue
+        }
+
+        if line.hasPrefix("[") && line.hasSuffix("]") {
+            var sectionName = String(line.dropFirst().dropLast()).trimmingCharacters(in: .whitespaces)
+            if sectionName.hasPrefix("profile ") {
+                sectionName = String(sectionName.dropFirst("profile ".count))
+            }
+            currentSection = sectionName
+            if sections[sectionName] == nil {
+                sections[sectionName] = [:]
+            }
+            continue
+        }
+
+        guard let currentSection,
+              let separator = line.firstIndex(of: "=")
+        else {
+            continue
+        }
+
+        let key = line[..<separator].trimmingCharacters(in: .whitespaces)
+        let value = line[line.index(after: separator)...].trimmingCharacters(in: .whitespaces)
+        sections[currentSection]?[key] = value
+    }
+
+    return sections
 }
 
-struct Creds: Codable {
-    var ssoCreds: SsoCreds
-    var roleCreds: RoleCreds?
+func loadConfig() throws -> AWSEALConfig {
+    let home = FileManager.default.homeDirectoryForCurrentUser
+    let awsealConfigURL = home.appendingPathComponent(".awseal/config.json")
+    let awsConfigURL = home.appendingPathComponent(".aws/config")
+    var profiles: [String: AWSEALProfile] = [:]
+
+    if FileManager.default.fileExists(atPath: awsealConfigURL.path) {
+        profiles.merge(try AWSEALConfig.load(fromJSON: awsealConfigURL).profiles) { _, new in new }
+    }
+
+    if FileManager.default.fileExists(atPath: awsConfigURL.path) {
+        profiles.merge(try AWSEALConfig.load(fromAWSConfig: awsConfigURL).profiles) { _, new in new }
+    }
+
+    if profiles.isEmpty {
+        throw AwsealError.generic("No awseal profiles found in ~/.aws/config or ~/.awseal/config.json")
+    }
+
+    return AWSEALConfig(profiles: profiles)
 }
 
 struct RoleCreds: Codable {
@@ -261,9 +353,59 @@ struct SsoCreds: Codable {
     var refreshToken: String?
 }
 
+func cacheKey(_ value: String) -> String {
+    SHA256.hash(data: Data(value.utf8)).map { String(format: "%02x", $0) }.joined()
+}
+
+func ssoCredsCacheFileName(ssoSession: String) -> String {
+    "sso-\(cacheKey(ssoSession))"
+}
+
+func roleCredsCacheFileName(profile: String) -> String {
+    "role-\(cacheKey(profile))"
+}
+
+func awsealDirectory() throws -> URL {
+    let homeDir = FileManager.default.homeDirectoryForCurrentUser
+    let dirURL = homeDir.appendingPathComponent(".awseal")
+
+    if !FileManager.default.fileExists(atPath: dirURL.path) {
+        do {
+            try FileManager.default.createDirectory(at: dirURL, withIntermediateDirectories: true)
+        } catch {
+            throw AwsealError.generic("Unable to create directory ~/.awseal")
+        }
+    }
+
+    return dirURL
+}
+
+func loadEncryptedJSON<T: Decodable>(fileName: String, as type: T.Type) throws -> T? {
+    let fileURL = try awsealDirectory().appendingPathComponent(fileName)
+
+    guard FileManager.default.fileExists(atPath: fileURL.path) else {
+        return nil
+    }
+
+    let data = try loadDecrypted(from: fileURL)
+    return try JSONDecoder().decode(type, from: data)
+}
+
+func saveEncryptedJSON<T: Encodable>(_ value: T, fileName: String) throws {
+    let fileURL = try awsealDirectory().appendingPathComponent(fileName)
+    let data = try JSONEncoder().encode(value)
+    try saveEncrypted(plaintext: data, to: fileURL)
+}
+
+func printError(_ message: String) {
+    if let data = message.data(using: .utf8) {
+        FileHandle.standardError.write(data)
+    }
+}
+
 func ssoLogin(
     oidc: SSOOIDCClient,
-    profile: String,
+    ssoSession: String,
     ssoCreds: SsoCreds,
     ssoStartUrl: String
 ) async throws -> SsoCreds {
@@ -284,10 +426,11 @@ func ssoLogin(
     let verificationUriComplete = resp.verificationUriComplete
     let interval = resp.interval
 
-    print("""
-    To complete SSO login, open the following URL in your browser and confirm / enter the code (\(userCode)) if required:
+    printError("""
+    To complete SSO login for \(ssoSession), open the following URL in your browser and confirm / enter the code (\(userCode)) if required:
 
       \(verificationUriComplete ?? verificationUri ?? "<no verification URL>")
+    \n
     """)
 
     if let urlString = verificationUriComplete ?? verificationUri,
@@ -326,39 +469,27 @@ func ssoLogin(
     throw AwsealError.generic("Device authorization timed out.")
 }
 
-func loadCreds(profile: String) throws -> Creds? {
-    let homeDir = FileManager.default.homeDirectoryForCurrentUser
-    let fileURL = homeDir.appendingPathComponent(".awseal/\(profile)")
-
-    guard FileManager.default.fileExists(atPath: fileURL.path) else {
-        return nil
-    }
-
-    let data = try loadDecrypted(from: fileURL)
-    return try JSONDecoder().decode(Creds.self, from: data)
+func loadSsoCreds(profileConfig: AWSEALProfile) throws -> SsoCreds? {
+    let fileName = ssoCredsCacheFileName(ssoSession: profileConfig.effectiveSsoSession)
+    return try loadEncryptedJSON(fileName: fileName, as: SsoCreds.self)
 }
 
-func saveCreds(profile: String, creds: Creds) throws {
-    let homeDir = FileManager.default.homeDirectoryForCurrentUser
-    let dirURL = homeDir.appendingPathComponent(".awseal")
-
-    if !FileManager.default.fileExists(atPath: dirURL.path) {
-        do {
-            try FileManager.default.createDirectory(at: dirURL, withIntermediateDirectories: true)
-        } catch {
-            throw AwsealError.generic("Unable to create directory ~/.awseal")
-        }
-    }
-
-    let fileURL = dirURL.appendingPathComponent(profile)
-
-    let data = try JSONEncoder().encode(creds)
-    try saveEncrypted(plaintext: data, to: fileURL)
+func saveSsoCreds(ssoSession: String, ssoCreds: SsoCreds) throws {
+    try saveEncryptedJSON(ssoCreds, fileName: ssoCredsCacheFileName(ssoSession: ssoSession))
 }
 
-func registerClient(oidc: SSOOIDCClient, profile: String) async throws -> SsoCreds {
+func loadRoleCreds(profile: String) throws -> RoleCreds? {
+    let fileName = roleCredsCacheFileName(profile: profile)
+    return try loadEncryptedJSON(fileName: fileName, as: RoleCreds.self)
+}
+
+func saveRoleCreds(profile: String, roleCreds: RoleCreds) throws {
+    try saveEncryptedJSON(roleCreds, fileName: roleCredsCacheFileName(profile: profile))
+}
+
+func registerClient(oidc: SSOOIDCClient, ssoSession: String) async throws -> SsoCreds {
     let input = RegisterClientInput(
-        clientName: "awseal-\(profile)",
+        clientName: "awseal-\(cacheKey(ssoSession).prefix(16))",
         clientType: "public",
         grantTypes: [
             "urn:ietf:params:oauth:grant-type:device_code",
@@ -379,7 +510,37 @@ func registerClient(oidc: SSOOIDCClient, profile: String) async throws -> SsoCre
     return ssoCreds
 }
 
-func refreshAccessToken(profile: String, oidc: SSOOIDCClient, ssoCreds: SsoCreds) async throws -> (String, String) {
+func loginToSso(profileConfig: AWSEALProfile, oidc: SSOOIDCClient) async throws -> SsoCreds {
+    let ssoSession = profileConfig.effectiveSsoSession
+    var ssoCreds: SsoCreds
+    if let existing = try loadSsoCreds(profileConfig: profileConfig) {
+        ssoCreds = existing
+    } else {
+        ssoCreds = try await registerClient(oidc: oidc, ssoSession: ssoSession)
+    }
+
+    do {
+        ssoCreds = try await ssoLogin(
+            oidc: oidc,
+            ssoSession: ssoSession,
+            ssoCreds: ssoCreds,
+            ssoStartUrl: profileConfig.ssoStartUrl
+        )
+    } catch is InvalidClientException, is UnauthorizedException {
+        ssoCreds = try await registerClient(oidc: oidc, ssoSession: ssoSession)
+        ssoCreds = try await ssoLogin(
+            oidc: oidc,
+            ssoSession: ssoSession,
+            ssoCreds: ssoCreds,
+            ssoStartUrl: profileConfig.ssoStartUrl
+        )
+    }
+
+    try saveSsoCreds(ssoSession: ssoSession, ssoCreds: ssoCreds)
+    return ssoCreds
+}
+
+func refreshAccessToken(oidc: SSOOIDCClient, ssoCreds: SsoCreds) async throws -> SsoCreds {
     guard let refreshToken = ssoCreds.refreshToken else {
         throw AwsealError.notLoggedIn
     }
@@ -400,7 +561,7 @@ func refreshAccessToken(profile: String, oidc: SSOOIDCClient, ssoCreds: SsoCreds
             if let refreshToken = tok.refreshToken {
                 updatedCreds.refreshToken = refreshToken
             }
-            return (accessToken, refreshToken)
+            return updatedCreds
         }
         throw AwsealError.notLoggedIn
     } catch is ExpiredTokenException {
@@ -425,21 +586,34 @@ func getRoleCreds(sso: SSOClient, accessToken: String, accountId: String, roleNa
 }
 
 func fetchRoleCreds(
-    profile: String, oidc: SSOOIDCClient, sso: SSOClient, region: String, accountId: String, roleName: String
+    profile: String, profileConfig: AWSEALProfile, oidc: SSOOIDCClient, sso: SSOClient, autologin: Bool
 ) async throws -> RoleCreds {
-
-    guard var creds = try loadCreds(profile: profile) else {
-        throw AwsealError.notLoggedIn
-    }
     
-    if let roleCreds = creds.roleCreds {
+    if let roleCreds = try loadRoleCreds(profile: profile) {
         if !roleCreds.hasExpired {
             return roleCreds
         }
     }
     // role creds not present or expired
 
-    guard let accessToken = creds.ssoCreds.accessToken else {
+    var ssoCreds: SsoCreds
+    if let existing = try loadSsoCreds(profileConfig: profileConfig) {
+        ssoCreds = existing
+    } else {
+        guard autologin else {
+            throw AwsealError.notLoggedIn
+        }
+        ssoCreds = try await loginToSso(profileConfig: profileConfig, oidc: oidc)
+    }
+
+    if ssoCreds.accessToken == nil {
+        guard autologin else {
+            throw AwsealError.notLoggedIn
+        }
+        ssoCreds = try await loginToSso(profileConfig: profileConfig, oidc: oidc)
+    }
+
+    guard let accessToken = ssoCreds.accessToken else {
         throw AwsealError.notLoggedIn
     }
 
@@ -448,26 +622,35 @@ func fetchRoleCreds(
         roleCreds = try await getRoleCreds(
             sso: sso,
             accessToken: accessToken,
-            accountId: accountId,
-            roleName: roleName
+            accountId: profileConfig.accountId,
+            roleName: profileConfig.roleName
         )
     } catch is UnauthorizedException {
-        let (accessToken, refreshToken) = try await refreshAccessToken(
-            profile: profile,
-            oidc: oidc,
-            ssoCreds: creds.ssoCreds
-        )
-        creds.ssoCreds.accessToken = accessToken
-        creds.ssoCreds.refreshToken = refreshToken
+        do {
+            ssoCreds = try await refreshAccessToken(
+                oidc: oidc,
+                ssoCreds: ssoCreds
+            )
+            try saveSsoCreds(ssoSession: profileConfig.effectiveSsoSession, ssoCreds: ssoCreds)
+        } catch {
+            guard autologin else {
+                throw error
+            }
+            ssoCreds = try await loginToSso(profileConfig: profileConfig, oidc: oidc)
+        }
+
+        guard let accessToken = ssoCreds.accessToken else {
+            throw AwsealError.notLoggedIn
+        }
+
         roleCreds = try await getRoleCreds(
             sso: sso,
             accessToken: accessToken,
-            accountId: accountId,
-            roleName: roleName
+            accountId: profileConfig.accountId,
+            roleName: profileConfig.roleName
         )
     }
-    creds.roleCreds = roleCreds
-    try saveCreds(profile: profile, creds: creds)
+    try saveRoleCreds(profile: profile, roleCreds: roleCreds)
     return roleCreds
 }
 
@@ -525,6 +708,14 @@ struct Options: ParsableArguments {
     var profile = "default"
 }
 
+struct FetchRoleCredsOptions: ParsableArguments {
+    @Option(name: [.long, .customShort("p")], help: "The profile to use.")
+    var profile = "default"
+
+    @Flag(help: "Open a browser and login when cached SSO credentials are missing or cannot be refreshed.")
+    var autologin = false
+}
+
 extension Awseal {
     struct Login: AsyncParsableCommand {
         static let configuration = CommandConfiguration(
@@ -537,34 +728,7 @@ extension Awseal {
             let config = try loadConfig()
             let profileConfig = try config.profile(named: options.profile)
             let oidc = try SSOOIDCClient(region: profileConfig.ssoRegion)
-            var creds: Creds
-            if let existing = try loadCreds(profile: options.profile) {
-                creds = existing
-            } else {
-                let ssoCreds = try await registerClient(oidc: oidc, profile: options.profile)
-                creds = Creds(ssoCreds: ssoCreds)
-            }
-
-            var ssoCreds: SsoCreds
-            do {
-                ssoCreds = try await ssoLogin(
-                    oidc: oidc,
-                    profile: options.profile,
-                    ssoCreds: creds.ssoCreds,
-                    ssoStartUrl: profileConfig.ssoStartUrl
-                )
-            } catch is InvalidClientException, is UnauthorizedException {
-                ssoCreds = try await registerClient(oidc: oidc, profile: options.profile)
-                creds = Creds(ssoCreds: ssoCreds)
-                ssoCreds = try await ssoLogin(
-                    oidc: oidc,
-                    profile: options.profile,
-                    ssoCreds: creds.ssoCreds,
-                    ssoStartUrl: profileConfig.ssoStartUrl
-                )
-            }
-            creds.ssoCreds = ssoCreds
-            try saveCreds(profile: options.profile, creds: creds)
+            _ = try await loginToSso(profileConfig: profileConfig, oidc: oidc)
         }
     }
 
@@ -573,7 +737,7 @@ extension Awseal {
             abstract: "Fetch and print role credentials for AWS CLI credential_process use."
         )
 
-        @OptionGroup var options: Options
+        @OptionGroup var options: FetchRoleCredsOptions
 
         func run() async throws {
             let config = try loadConfig()
@@ -582,11 +746,10 @@ extension Awseal {
             let sso = try SSOClient(region: profileConfig.region)
             let creds = try await fetchRoleCreds(
                 profile: options.profile,
+                profileConfig: profileConfig,
                 oidc: oidc,
                 sso: sso,
-                region: profileConfig.region,
-                accountId: profileConfig.accountId,
-                roleName: profileConfig.roleName
+                autologin: options.autologin
             )
             printRoleCredentials(creds: creds)
         }


### PR DESCRIPTION
## Summary
- share encrypted SSO credentials across profiles using `awseal_sso_session` or start URL/region
- keep role credentials cached per profile and delete expired role caches after detecting expiry
- add `--autologin` for credential_process flows that need browser SSO login
- load `awseal_sso_*` config from `~/.aws/config` and add `awseal migrate` for vanilla AWS SSO configs
- improve Touch ID prompt text with profile/session and selected parent command

## Verification
- `swift build`
- `swift build -c release`
- local migration dry-run tests against temporary AWS config files
